### PR TITLE
Fix remote server access after initial password setup

### DIFF
--- a/VibeTunnel/Presentation/Views/WelcomeView.swift
+++ b/VibeTunnel/Presentation/Views/WelcomeView.swift
@@ -350,6 +350,11 @@ private struct ProtectDashboardPageView: View {
             ) ?? .localhost
             if currentMode == .localhost {
                 UserDefaults.standard.set(DashboardAccessMode.network.rawValue, forKey: "dashboardAccessMode")
+                
+                // Restart server to apply new bind address for network access
+                Task {
+                    await ServerManager.shared.restart()
+                }
             }
         } else {
             errorMessage = "Failed to save password to keychain"


### PR DESCRIPTION
## Summary
- Fixes issue where external server access fails after initial installation 
- Server now automatically restarts when switching from localhost to network mode during password setup
- Ensures proper network binding for external access

## Problem
When users install VibeTunnel and set up a password for the first time:
1. App starts with server bound to localhost (127.0.0.1)  
2. Password setup switches access mode to network
3. Server continues running on localhost binding
4. External IP access fails until app restart

## Solution
- Add server restart after password configuration in WelcomeView
- Server rebinds to 0.0.0.0 when switching to network mode
- External access works immediately without app restart

Fixes #11